### PR TITLE
Support PSP hostPorts

### DIFF
--- a/advisor/processor/generate.go
+++ b/advisor/processor/generate.go
@@ -114,6 +114,11 @@ func (p *Processor) GeneratePSP(cssList []types.ContainerSecuritySpec, pssList [
 		if sc.AllowPrivilegeEscalation != nil && !*sc.AllowPrivilegeEscalation {
 			notAllowPrivilegeEscationCount++
 		}
+
+		// set host ports
+		for _, port := range sc.HostPorts {
+			psp.Spec.HostPorts = append(psp.Spec.HostPorts, v1beta1.HostPortRange{Min: port, Max: port})
+		}
 	}
 
 	// set allowedPrivilegeEscalation

--- a/advisor/processor/get.go
+++ b/advisor/processor/get.go
@@ -51,6 +51,7 @@ func getSecuritySpec(metadata types.Metadata, namespace string, spec v1.PodSpec)
 			Privileged:               getPrivileged(container.SecurityContext),
 			RunAsGroup:               getRunAsGroup(container.SecurityContext, spec.SecurityContext),
 			RunAsUser:                getRunAsUser(container.SecurityContext, spec.SecurityContext),
+			HostPorts:                getHostPorts(container.Ports),
 		}
 		cssList = append(cssList, csc)
 	}

--- a/advisor/types/securityspec.go
+++ b/advisor/types/securityspec.go
@@ -52,6 +52,7 @@ type ContainerSecuritySpec struct {
 	AllowPrivilegeEscalation *bool    `json:"allowPrivilegeEscalation,omitempty"`
 	RunAsUser                *int64   `json:"runAsUser,omitempty"`
 	RunAsGroup               *int64   `json:"runAsGroup,omitempty"`
+	HostPorts                []int32  `json:"hostPorts,omitempty"`
 }
 
 type PodSecuritySpec struct {


### PR DESCRIPTION
This PR add support for PSP hostPorts. `getHostPorts` function was already defined, so I guess that it was forgot to implement.