### PR TITLE
Add "secret" volume type if serviceaccount token is mounted

### DIFF
--- a/advisor/processor/generate.go
+++ b/advisor/processor/generate.go
@@ -18,6 +18,7 @@ type Processor struct {
 	k8sClient          *kubernetes.Clientset
 	resourceNamePrefix map[string]bool
 	namespace          string
+	serviceAccountMap  map[string]v1.ServiceAccount
 }
 
 func NewProcessor(kubeconfig string) (*Processor, error) {
@@ -229,6 +230,13 @@ func (p *Processor) GenerateReport(cssList []types.ContainerSecuritySpec, pssLis
 func (p *Processor) GetSecuritySpec() ([]types.ContainerSecuritySpec, []types.PodSecuritySpec, error) {
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
+
+	// get and cache service account list in the specified namespace
+	var err error
+	p.serviceAccountMap, err = p.getServiceAccountMap()
+	if err != nil {
+		return cssList, pssList, err
+	}
 
 	// get security spec from daemonsets
 	cspList0, pspList0, err := p.getSecuritySpecFromDaemonSets()


### PR DESCRIPTION
This PR fixes to add "secret" volume type if serviceaccount token is mounted.

If you don't opt out of automounting API credentials for a service account by setting `automountServiceAccountToken: false` on the service account or a particular pod, PSP volume types needs to include "secret" volume type.

See https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server for more details.