### PR TITLE
suppress host ports for now as require getting listening port 

### DIFF
--- a/advisor/processor/generate.go
+++ b/advisor/processor/generate.go
@@ -117,9 +117,10 @@ func (p *Processor) GeneratePSP(cssList []types.ContainerSecuritySpec, pssList [
 		}
 
 		// set host ports
-		for _, port := range sc.HostPorts {
-			psp.Spec.HostPorts = append(psp.Spec.HostPorts, v1beta1.HostPortRange{Min: port, Max: port})
-		}
+		// TODO: need to integrate with listening port during the runtime, might cause false positive.
+		//for _, port := range sc.HostPorts {
+		//	psp.Spec.HostPorts = append(psp.Spec.HostPorts, v1beta1.HostPortRange{Min: port, Max: port})
+		//}
 	}
 
 	// set allowedPrivilegeEscalation


### PR DESCRIPTION
```
	// List of ports to expose from the container. Exposing a port here gives
	// the system additional information about the network connections a
	// container uses, but is primarily informational. Not specifying a port here
	// DOES NOT prevent that port from being exposed. Any port which is
	// listening on the default "0.0.0.0" address inside a container will be
	// accessible from the network.
	// Cannot be updated.
	// +optional
	// +patchMergeKey=containerPort
	// +patchStrategy=merge
	// +listType=map
	// +listMapKey=containerPort
	// +listMapKey=protocol
	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
```

Need further investigation.