### PR TITLE
Allow access to advisor.podSecurityPolicy from external package

### DIFF
--- a/advisor/advisor.go
+++ b/advisor/advisor.go
@@ -68,3 +68,7 @@ func (advisor *Advisor) PrintPodSecurityPolicy() error {
 
 	return err
 }
+
+func (advisor *Advisor) GetPodSecurityPolicy() *v1beta1.PodSecurityPolicy {
+	return advisor.podSecurityPolicy
+}


### PR DESCRIPTION
I want to integrate with another tool to generate PodSecurityPolicy.

However, the `podSecurityPolicy` of the `Advisor struct` cannot be accessed from the external.

```go
type Advisor struct {
    podSecurityPolicy *v1beta1.PodSecurityPolicy
    k8sClient         *kubernetes.Clientset
    processor         *processor.Processor
    report            *report.Report
}
```

So I made this field accessible from the external.