### PR TITLE
WIP: Setting default psp

### DIFF
--- a/kube-psp-advisor.go
+++ b/kube-psp-advisor.go
@@ -75,9 +75,11 @@ func convertPsp(podObjFilename string, pspFilename string, defaultPspFile string
 		return fmt.Errorf("failed to create PSP Generator: %v", err)
 	}
 
-	err = psp_gen.SetDefaultPspFromFile(defaultPspFile)
-	if err != nil {
-		return fmt.Errorf("Could not set default PSP: %v", err)
+	if defaultPspFile != "" {
+		err = psp_gen.SetDefaultPspFromFile(defaultPspFile)
+		if err != nil {
+			return fmt.Errorf("Could not set default PSP: %v", err)
+		}
 	}
 
 	pspString, err := psp_gen.FromPodObjString(string(podObjString))

--- a/kube-psp-advisor.go
+++ b/kube-psp-advisor.go
@@ -53,7 +53,7 @@ func inspectPsp(kubeconfig string, namespace string, withReport, withGrant bool)
 	return nil
 }
 
-func convertPsp(podObjFilename string, pspFilename string) error {
+func convertPsp(podObjFilename string, pspFilename string, defaultPspFile string) error {
 	podObjFile, err := os.Open(podObjFilename)
 	if err != nil {
 		return fmt.Errorf("Could not open pod object file %s for reading: %v", podObjFilename, err)
@@ -73,6 +73,11 @@ func convertPsp(podObjFilename string, pspFilename string) error {
 	psp_gen, err := generator.NewGenerator()
 	if err != nil {
 		return fmt.Errorf("failed to create PSP Generator: %v", err)
+	}
+
+	err = psp_gen.SetDefaultPspFromFile(defaultPspFile)
+	if err != nil {
+		return fmt.Errorf("Could not set default PSP: %v", err)
 	}
 
 	pspString, err := psp_gen.FromPodObjString(string(podObjString))
@@ -133,6 +138,7 @@ func main() {
 	var namespace string
 	var podObjFilename string
 	var pspFilename string
+	var defaultPspFilename string
 	var logLevel string
 	var srcYamlDir string
 	var targetYamlDir string
@@ -184,7 +190,7 @@ func main() {
 		},
 
 		Run: func(cmd *cobra.Command, args []string) {
-			err := convertPsp(podObjFilename, pspFilename)
+			err := convertPsp(podObjFilename, pspFilename, defaultPspFilename)
 			if err != nil {
 				log.Fatalf("Could not run convert command: %v", err)
 			}
@@ -224,6 +230,7 @@ func main() {
 
 	convertCmd.Flags().StringVar(&podObjFilename, "podFile", "", "Path to a yaml file containing an object with a pod Spec")
 	convertCmd.Flags().StringVar(&pspFilename, "pspFile", "", "Write the resulting PSP to this file")
+	convertCmd.Flags().StringVar(&defaultPspFilename, "defaultPspFile", "", "Path to a yaml file containing default Pod Security Policy.")
 
 	compareCmd.Flags().StringVar(&srcYamlDir, "sourceDir", "", "Source YAML directory to load YAMLs")
 	compareCmd.Flags().StringVar(&targetYamlDir, "targetDir", "", "Target YAML directory to load YAMLs")


### PR DESCRIPTION
I want to set default PSP when converting.

kube-psp-advisor is very cool tool!! 
We use this tool for creating psp.

kube-psp-advisor `convert` however makes some fields which are not defined in a manifest loose rules.
EX) Default setting of runAsUser is "RunAsAny".

We want to change these default settings.
Therefore I have tried to make prototype which read default psp setting form a file.

If this idea is accepted, I do rest work to do.(Apply all fields, make tests...)
How do you think?

I write example in following.

This is sample deployment manifest.

``` test-deploy.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
  creationTimestamp: "2020-05-23T12:12:08Z"
  generation: 1
  labels:
    k8s-app: kube-dns
  name: coredns
  namespace: kube-system
  resourceVersion: "14048"
  selfLink: /apis/apps/v1/namespaces/kube-system/deployments/coredns
  uid: c0bb78cc-fbb3-4ede-9f95-1a54b87b8775
spec:
  progressDeadlineSeconds: 600
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      k8s-app: kube-dns
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        k8s-app: kube-dns
    spec:
      containers:
      - args:
        - -conf
        - /etc/coredns/Corefile
        image: k8s.gcr.io/coredns:1.6.2
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 5
          httpGet:
            path: /health
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 60
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 5
        name: coredns
        ports:
        - containerPort: 53
          name: dns
          protocol: UDP
        - containerPort: 53
          name: dns-tcp
          protocol: TCP
        - containerPort: 9153
          name: metrics
          protocol: TCP
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /ready
            port: 8181
            scheme: HTTP
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          limits:
            memory: 170Mi
          requests:
            cpu: 100m
            memory: 70Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            add:
            - NET_BIND_SERVICE
            drop:
            - all
          readOnlyRootFilesystem: true
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /etc/coredns
          name: config-volume
          readOnly: true
      dnsPolicy: Default
      nodeSelector:
        beta.kubernetes.io/os: linux
      priorityClassName: system-cluster-critical
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: coredns
      serviceAccountName: coredns
      terminationGracePeriodSeconds: 30
      tolerations:
      - key: CriticalAddonsOnly
        operator: Exists
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      volumes:
      - configMap:
          defaultMode: 420
          items:
          - key: Corefile
            path: Corefile
          name: coredns
        name: config-volume
status:
  availableReplicas: 2
  conditions:
  - lastTransitionTime: "2020-05-23T12:12:15Z"
    lastUpdateTime: "2020-05-23T12:12:24Z"
    message: ReplicaSet "coredns-5644d7b6d9" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  - lastTransitionTime: "2020-05-30T07:17:32Z"
    lastUpdateTime: "2020-05-30T07:17:32Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  observedGeneration: 1
  readyReplicas: 2
  replicas: 2
  updatedReplicas: 2
```

This is sample default psp file.

```yaml
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  name: example
spec:
  seLinux:
    rule: RunAsAny
  runAsUser:
    rule: MustRunAs
    ranges:
      - min: 1
        max: 65535
  fsGroup:
    rule: RunAsAny
  volumes:
  - '*'
```

Without default psp file.

```
 ./kube-psp-advisor convert --podFile test-deploy.yaml --pspFile output-psp.yaml && cat output-psp.yaml                                                                        [~/go/src/kube-psp-advisor]
INFO[2020-05-31T10:12:23+09:00] Wrote generated psp to output-psp.yaml
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  creationTimestamp: null
  name: pod-security-policy-default-20200531101223
spec:
  allowPrivilegeEscalation: false
  defaultAddCapabilities:
  - NET_BIND_SERVICE
  fsGroup:
    rule: RunAsAny
  hostPorts:
  - max: 0
    min: 0
  readOnlyRootFilesystem: true
  requiredDropCapabilities:
  - all
  runAsGroup:
    rule: RunAsAny
  runAsUser:
    rule: RunAsAny
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    rule: RunAsAny
  volumes:
  - configMap
  - secret
```


with default psp file

```
$ ./kube-psp-advisor convert --podFile test-deploy.yaml --pspFile output-psp.yaml --defaultPspFile ./test-psp.yaml && cat output-psp.yaml                                       [~/go/src/kube-psp-advisor]
INFO[2020-05-31T10:13:05+09:00] Wrote generated psp to output-psp.yaml
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  creationTimestamp: null
  name: pod-security-policy-default-20200531101305
spec:
  allowPrivilegeEscalation: false
  defaultAddCapabilities:
  - NET_BIND_SERVICE
  fsGroup:
    rule: RunAsAny
  hostPorts:
  - max: 0
    min: 0
  readOnlyRootFilesystem: true
  requiredDropCapabilities:
  - all
  runAsGroup:
    rule: RunAsAny
  runAsUser:                           <= replaced by default setting
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    rule: RunAsAny
  volumes:
  - configMap
  - secret
```
