### PR TITLE
add --exclude-namespaces parameter

### DIFF
--- a/advisor/advisor.go
+++ b/advisor/advisor.go
@@ -41,8 +41,9 @@ func NewAdvisor(kubeconfig string) (*Advisor, error) {
 	}, nil
 }
 
-func (advisor *Advisor) Process(namespace string) error {
+func (advisor *Advisor) Process(namespace string, excludeNamespaces []string) error {
 	advisor.processor.SetNamespace(namespace)
+	advisor.processor.SetExcludeNamespaces(excludeNamespaces)
 
 	cssList, pssList, err := advisor.processor.GetSecuritySpec()
 

--- a/advisor/processor/generate.go
+++ b/advisor/processor/generate.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/sysdiglabs/kube-psp-advisor/advisor/report"
 	"github.com/sysdiglabs/kube-psp-advisor/advisor/types"
@@ -17,6 +18,7 @@ import (
 type Processor struct {
 	k8sClient         *kubernetes.Clientset
 	namespace         string
+	excludeNamespaces []string // excludeNamespaces is a slice of namespaces that will be excluded from processing
 	serviceAccountMap map[string]v1.ServiceAccount
 	serverGitVersion  string
 	gen               *generator.Generator
@@ -54,6 +56,22 @@ func NewProcessor(kubeconfig string) (*Processor, error) {
 
 func (p *Processor) SetNamespace(ns string) {
 	p.namespace = ns
+}
+
+func (p *Processor) SetExcludeNamespaces(excludeNamespaces []string) {
+	p.excludeNamespaces = excludeNamespaces
+}
+
+func (p *Processor) getFieldSelector() string {
+	var list []string
+	for _, ns := range p.excludeNamespaces {
+		if ns == "" {
+			continue
+		}
+		list = append(list, "metadata.namespace!="+ns)
+	}
+
+	return strings.Join(list, ",")
 }
 
 // GeneratePSP generates Pod Security Policy

--- a/advisor/processor/generate_test.go
+++ b/advisor/processor/generate_test.go
@@ -1,0 +1,21 @@
+package processor
+
+import "testing"
+
+func TestGetFieldSelector(t *testing.T) {
+	p := Processor{
+		excludeNamespaces: []string{
+			"ns1",
+			"",
+			"ns3",
+			"ns4",
+			"",
+		},
+	}
+
+	expected := "metadata.namespace!=ns1,metadata.namespace!=ns3,metadata.namespace!=ns4"
+
+	if p.getFieldSelector() != expected {
+		t.Fatalf("expected field selector to match %s", expected)
+	}
+}

--- a/advisor/processor/get.go
+++ b/advisor/processor/get.go
@@ -25,7 +25,8 @@ func (p *Processor) getSecuritySpecFromDaemonSets() ([]types.ContainerSecuritySp
 	cspList := []types.ContainerSecuritySpec{}
 	pspList := []types.PodSecuritySpec{}
 
-	daemonSetList, err := clientset.AppsV1().DaemonSets(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	daemonSetList, err := clientset.AppsV1().DaemonSets(p.namespace).List(lo)
 
 	if err != nil {
 		return cspList, pspList, err
@@ -51,7 +52,8 @@ func (p *Processor) getSecuritySpecFromReplicaSets() ([]types.ContainerSecurityS
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	replicaSetList, err := clientset.AppsV1().ReplicaSets(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	replicaSetList, err := clientset.AppsV1().ReplicaSets(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -80,7 +82,8 @@ func (p *Processor) getSecuritySpecFromStatefulSets() ([]types.ContainerSecurity
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	statefulSetList, err := clientset.AppsV1().StatefulSets(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	statefulSetList, err := clientset.AppsV1().StatefulSets(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -105,7 +108,8 @@ func (p *Processor) getSecuritySpecFromReplicationController() ([]types.Containe
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	replicationControllerList, err := clientset.CoreV1().ReplicationControllers(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	replicationControllerList, err := clientset.CoreV1().ReplicationControllers(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -130,7 +134,8 @@ func (p *Processor) getSecuritySpecFromCronJobs() ([]types.ContainerSecuritySpec
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	jobList, err := clientset.BatchV1beta1().CronJobs(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	jobList, err := clientset.BatchV1beta1().CronJobs(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -155,7 +160,8 @@ func (p *Processor) getSecuritySpecFromJobs() ([]types.ContainerSecuritySpec, []
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	jobList, err := clientset.BatchV1().Jobs(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	jobList, err := clientset.BatchV1().Jobs(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -183,7 +189,8 @@ func (p *Processor) getSecuritySpecFromDeployments() ([]types.ContainerSecurityS
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	deployments, err := clientset.AppsV1().Deployments(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	deployments, err := clientset.AppsV1().Deployments(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -208,7 +215,8 @@ func (p *Processor) getSecuritySpecFromPods() ([]types.ContainerSecuritySpec, []
 	cssList := []types.ContainerSecuritySpec{}
 	pssList := []types.PodSecuritySpec{}
 
-	pods, err := clientset.CoreV1().Pods(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	pods, err := clientset.CoreV1().Pods(p.namespace).List(lo)
 
 	if err != nil {
 		return cssList, pssList, err
@@ -235,7 +243,8 @@ func (p *Processor) getSecuritySpecFromPods() ([]types.ContainerSecuritySpec, []
 func (p *Processor) getServiceAccountMap() (map[string]v1.ServiceAccount, error) {
 	serviceAccountMap := map[string]v1.ServiceAccount{}
 
-	serviceAccounts, err := p.k8sClient.CoreV1().ServiceAccounts(p.namespace).List(v1meta.ListOptions{})
+	lo := v1meta.ListOptions{FieldSelector: p.getFieldSelector()}
+	serviceAccounts, err := p.k8sClient.CoreV1().ServiceAccounts(p.namespace).List(lo)
 	if err != nil {
 		return serviceAccountMap, err
 	}

--- a/kube-psp-advisor.go
+++ b/kube-psp-advisor.go
@@ -23,14 +23,14 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-func inspectPsp(kubeconfig string, namespace string, withReport, withGrant bool) error {
+func inspectPsp(kubeconfig string, namespace string, excludeNamespaces []string, withReport, withGrant bool) error {
 	advisor, err := advisor.NewAdvisor(kubeconfig)
 
 	if err != nil {
 		return fmt.Errorf("Could not create advisor object: %v", err)
 	}
 
-	err = advisor.Process(namespace)
+	err = advisor.Process(namespace, excludeNamespaces)
 
 	if err != nil {
 		return fmt.Errorf("Could not run advisor to inspect cluster and generate PSP: %v", err)
@@ -131,6 +131,7 @@ func main() {
 	var withReport bool
 	var withGrant bool
 	var namespace string
+	var excludeNamespaces []string
 	var podObjFilename string
 	var pspFilename string
 	var logLevel string
@@ -162,7 +163,7 @@ func main() {
 		Short: "Inspect a live K8s Environment to generate a PodSecurityPolicy",
 		Long:  "Fetch all objects in the provided namespace to generate a Pod Security Policy",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := inspectPsp(kubeconfig, namespace, withReport, withGrant)
+			err := inspectPsp(kubeconfig, namespace, excludeNamespaces, withReport, withGrant)
 			if err != nil {
 				log.Fatalf("Could not run inspect command: %v", err)
 			}
@@ -221,6 +222,7 @@ func main() {
 	inspectCmd.Flags().BoolVarP(&withReport, "report", "r", false, "(optional) return with detail report")
 	inspectCmd.Flags().BoolVarP(&withGrant, "grant", "g", false, "(optional) return with pod security policies, roles and rolebindings")
 	inspectCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "(optional) namespace")
+	inspectCmd.Flags().StringSliceVarP(&excludeNamespaces, "exclude-namespaces", "e", []string{}, "(optional) comma separated list of namespaces to exclude")
 
 	convertCmd.Flags().StringVar(&podObjFilename, "podFile", "", "Path to a yaml file containing an object with a pod Spec")
 	convertCmd.Flags().StringVar(&pspFilename, "pspFile", "", "Write the resulting PSP to this file")


### PR DESCRIPTION
This parameter will exclude the comma separated list of namespaces from processing since often namespaces such as `kube-system` will require very different PSP than other tenant applications.

Example usage:
```console
$ ./kube-psp-advisor inspect --exclude-namespaces kube-system,default
```
```yaml
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  creationTimestamp: null
  name: pod-security-policy-all-20200928091609
spec:
  allowedHostPaths:
  - pathPrefix: /usr/share/zoneinfo/America/Los_Angeles
    readOnly: true
  - pathPrefix: /etc/ssl/certs
    readOnly: true
  fsGroup:
    rule: RunAsAny
  hostPorts:
  - max: 0
    min: 0
  runAsUser:
    rule: RunAsAny
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    rule: RunAsAny
  volumes:
  - emptyDir
  - downwardAPI
  - secret
  - hostPath
  - configMap
```